### PR TITLE
[concourse]: Add inspec tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
-results
+results/
+inspec.lock

--- a/README.md
+++ b/README.md
@@ -1,13 +1,93 @@
-# Concourse
-The concourse plan _only_ provides users access to the standalone [concourse binary](https://concourse.ci/binaries.html). It is provided with the intention that any user's who need to run concourse will write their own plan that depends on this package and provide their own runtime management.
+[![Build Status](https://dev.azure.com/chefcorp-partnerengineering/Chef%20Base%20Plans/_apis/build/status/chef-base-plans.concourse?branchName=master)](https://dev.azure.com/chefcorp-partnerengineering/Chef%20Base%20Plans/_build/latest?definitionId=201&branchName=master)
+
+# concourse
+
+Concourse is a pipeline-based continuous thing-doer.  This habitat plan _only_ provides users access to the standalone binaries.  As a result, anyone using this habitat package will need to write their own plan that depends on this package and provide their own runtime management.  See the [Additional Steps](#additional-steps) section for an example setup.
+
+Refer also to the [documentation](https://concourse-ci.org/docs.html)
+
+## Maintainers
+
+* The Core Planners: <chef-core-planners@chef.io>
+
+## Type of Package
+
+Binary package
+
+### Use as Dependency
+
+Binary packages can be set as runtime or build time dependencies. See [Defining your dependencies](https://www.habitat.sh/docs/developing-packages/developing-packages/#sts=Define%20Your%20Dependencies) for more information.
+
+To add core/concourse as a dependency, you can add one of the following to your plan file.
+
+##### Buildtime Dependency
+
+> pkg_build_deps=(core/concourse)
+
+##### Runtime dependency
+
+> pkg_deps=(core/concourse)
+
+### Use as Tool
+
+#### Installation
+
+To install this plan, you should run the following commands to first install, and then link the binaries this plan creates.
+
+``hab pkg install core/concourse --binlink``
+
+will add the following binary to the PATH:
+
+* /bin/concourse
+
+For example:
+
+```bash
+$ hab pkg install core/concourse --binlink
+» Installing core/concourse
+☁ Determining latest version of core/concourse in the 'stable' channel
+→ Found newer installed version (core/concourse/4.2.2/20200818102606) than remote version (core/concourse/4.2.2/20200404015818)
+→ Using core/concourse/4.2.2/20200818102606
+★ Install of core/concourse/4.2.2/20200818102606 complete with 0 new packages installed.
+» Binlinking concourse from core/concourse/4.2.2/20200818102606 into /bin
+★ Binlinked concourse from core/concourse/4.2.2/20200818102606 to /bin/concourse
+```
+
+#### Using an example binary
+
+You can now use the binary as normal.  For example:
+
+``/bin/concourse --help`` or ``concourse --help``
+
+```bash
+$ concourse --help
+Usage:
+  concourse [OPTIONS] <command>
+
+Application Options:
+  -v, --version  Print the version of Concourse and exit [$CONCOURSE_VERSION]
+
+Help Options:
+  -h, --help     Show this help message
+
+Available commands:
+  land-worker    Safely drain a worker's assignments for temporary downtime.
+  migrate
+  quickstart     Run both 'web' and 'worker' together, auto-wired. Not recommended for production.
+  retire-worker  Safely remove a worker from the cluster permanently.
+  web            Run the web UI and build scheduler.
+  worker         Run and register a worker.
+```
+
+#### Additional Steps
 
 Concourse is a complex piece of software with multiple ways in which it can be configured to run. As such we provide this package to enable you to wrap and automate your preferred deployment style.
 
-## Examples
 Below we have provided an example configuration for deploying Concourse.
 
 **concourse-web/plan.sh**
-```
+
+```bash
 pkg_name=concourse-web
 pkg_origin=eeyun
 pkg_version="0.1.0"
@@ -34,8 +114,8 @@ do_install(){
 ```
 
 **concourse-web/default.toml**
-```
 
+```toml
 [concourse]
 username = "concourse"
 password = "changeme"
@@ -49,8 +129,10 @@ username = "concourse"
 password = "changeme"
 dbname = "concourse"
 ```
+
 **concourse-web/hooks/run**
-```
+
+```bash
 #!/bin/bash -xe
 #
 exec 2>&1
@@ -73,8 +155,10 @@ concourse web \
     --tsa-host-key {{pkg.svc_files_path}}/tsa_host_key \
     --tsa-authorized-keys {{pkg.svc_files_path}}/authorized_worker_keys
 ```
+
 **concourse-web/config/config.sh**
-```
+
+```bash
 #!/bin/bash
 
 export CONCOURSE_BASIC_AUTH_USERNAME="{{cfg.concourse.username}}"

--- a/README.md
+++ b/README.md
@@ -1,2 +1,102 @@
-# base-plan-skeleton
-Template for all new Chef Base Plans to simplify creation of repositories.
+# Concourse
+The concourse plan _only_ provides users access to the standalone [concourse binary](https://concourse.ci/binaries.html). It is provided with the intention that any user's who need to run concourse will write their own plan that depends on this package and provide their own runtime management.
+
+Concourse is a complex piece of software with multiple ways in which it can be configured to run. As such we provide this package to enable you to wrap and automate your preferred deployment style.
+
+## Examples
+Below we have provided an example configuration for deploying Concourse.
+
+**concourse-web/plan.sh**
+```
+pkg_name=concourse-web
+pkg_origin=eeyun
+pkg_version="0.1.0"
+pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
+pkg_license=('Apache-2.0')
+pkg_deps=(core/concourse core/postgresql)
+pkg_exports=(
+   [web_port]=ports.web
+)
+pkg_exposes=(web_port)
+pkg_binds_optional=(
+   [database]="web_port host"
+)
+pkg_description="Some description."
+pkg_upstream_url="https://concourse.ci/"
+
+do_build(){
+  return 0
+}
+
+do_install(){
+  return 0
+}
+```
+
+**concourse-web/default.toml**
+```
+
+[concourse]
+username = "concourse"
+password = "changeme"
+
+[ports]
+web = "8080"
+
+[postgres]
+host_ip = "localhost"
+username = "concourse"
+password = "changeme"
+dbname = "concourse"
+```
+**concourse-web/hooks/run**
+```
+#!/bin/bash -xe
+#
+exec 2>&1
+
+source "{{pkg.svc_config_path}}/config.sh"
+
+cd {{pkg.svc_path}}
+
+PG_PASS=$CONCOURSE_POSTGRES_PASSWORD
+PG_HOST=$CONCOURSE_POSTGRES_HOST
+
+if PGPASSWORD=$PG_PASS psql -lqt -h $PG_HOST -U $CONCOURSE_POSTGRES_USER | cut -d \| -f 1 | grep -qw concourse; then
+    echo "first thing it work fine"
+else
+    PGPASSWORD=$PG_PASS createdb $CONCOURSE_POSTGRES_DATABASE -h $PG_HOST -U $CONCOURSE_POSTGRES_USER
+fi
+
+concourse web \
+    --session-signing-key {{pkg.svc_files_path}}/session_signing_key \
+    --tsa-host-key {{pkg.svc_files_path}}/tsa_host_key \
+    --tsa-authorized-keys {{pkg.svc_files_path}}/authorized_worker_keys
+```
+**concourse-web/config/config.sh**
+```
+#!/bin/bash
+
+export CONCOURSE_BASIC_AUTH_USERNAME="{{cfg.concourse.username}}"
+export CONCOURSE_BASIC_AUTH_PASSWORD="{{cfg.concourse.password}}"
+export CONCOURSE_EXTERNAL_URL="${CONCOURSE_EXTERNAL_URL}"
+
+{{#if bind.database ~}}
+{{#with bind.database.first as |pg| }}
+export CONCOURSE_POSTGRES_HOST="{{pg.sys.ip}}"
+export CONCOURSE_POSTGRES_USER="{{pg.cfg.superuser_name}}"
+export CONCOURSE_POSTGRES_PASSWORD="{{pg.cfg.superuser_password}}"
+export CONCOURSE_POSTGRES_DATABASE="{{cfg.postgres.dbname}}"
+{{/with}}
+{{else ~}}
+export CONCOURSE_POSTGRES_HOST="{{cfg.postgres.host_ip}}"
+export CONCOURSE_POSTGRES_USER="{{cfg.postgres.username}}"
+export CONCOURSE_POSTGRES_PASSWORD="{{cfg.postgres.password}}"
+{{/if ~}}
+
+export CONCOURSE_POSTGRES_DATABASE="{{cfg.postgres.dbname}}"
+```
+
+The above configuration when bound to a postgres instance with `--bind database:postgresql.default` gives you a concourse web server **WITH NO WORKER NODES**. It does not give you a working cluster and should only be used as an example for one possible shape of deployment. Following this pattern you would want to theoretically create ANOTHER package for concourse-worker that similarly starts a concourse worker and binds to concourse-web.
+
+With this above pattern you'll need to generate and upload the appropriate concourse keys to the appopriate service groups. In the case of the concourse-web example above that means generating and uploading the `session_signing_key`, the `tsa_host_key` and the `authorized_worker_keys`.

--- a/attributes.yml
+++ b/attributes.yml
@@ -1,0 +1,1 @@
+plan_name: 'concourse'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -15,4 +15,4 @@ resources:
 
 # Execute the stages from the main pipeline template
 stages:
-  - template: azure-pipelines.yml@plan_builder
+  - template: azure-pipelines-package-install.yml@plan_builder

--- a/botanist.yml
+++ b/botanist.yml
@@ -1,0 +1,4 @@
+---
+owners:
+  - "@echohack"
+  - "@habitat-sh/habitat-core-plans-maintainers"

--- a/controls/concourse_exists.rb
+++ b/controls/concourse_exists.rb
@@ -1,0 +1,26 @@
+title 'Tests to confirm concourse exists'
+
+plan_origin = ENV['HAB_ORIGIN']
+plan_name = input('plan_name', value: 'concourse')
+
+control 'core-plans-concourse-exists' do
+  impact 1.0
+  title 'Ensure concourse exists'
+  desc '
+  Verify concourse by ensuring bin/concourse 
+  (1) exists and
+  (2) is executable'
+  
+  plan_installation_directory = command("hab pkg path #{plan_origin}/#{plan_name}")
+  describe plan_installation_directory do
+    its('exit_status') { should eq 0 }
+    its('stdout') { should_not be_empty }
+    its('stderr') { should be_empty }
+  end
+
+  command_full_path = File.join(plan_installation_directory.stdout.strip, "bin", "concourse")
+  describe file(command_full_path) do
+    it { should exist }
+    it { should be_executable }
+  end
+end

--- a/controls/concourse_exists.rb
+++ b/controls/concourse_exists.rb
@@ -15,7 +15,6 @@ control 'core-plans-concourse-exists' do
   describe plan_installation_directory do
     its('exit_status') { should eq 0 }
     its('stdout') { should_not be_empty }
-    its('stderr') { should be_empty }
   end
 
   command_full_path = File.join(plan_installation_directory.stdout.strip, "bin", "concourse")

--- a/controls/concourse_works.rb
+++ b/controls/concourse_works.rb
@@ -1,0 +1,30 @@
+title 'Tests to confirm concourse works as expected'
+
+plan_origin = ENV['HAB_ORIGIN']
+plan_name = input('plan_name', value: 'concourse')
+
+control 'core-plans-concourse-works' do
+  impact 1.0
+  title 'Ensure concourse works as expected'
+  desc '
+  Verify concourse by ensuring that
+  (1) its installation directory exists 
+  (2) it returns the expected version
+  '
+  
+  plan_installation_directory = command("hab pkg path #{plan_origin}/#{plan_name}")
+  describe plan_installation_directory do
+    its('exit_status') { should eq 0 }
+    its('stdout') { should_not be_empty }
+    its('stderr') { should be_empty }
+  end
+  
+  plan_pkg_version = plan_installation_directory.stdout.split("/")[5]
+  command_full_path = File.join(plan_installation_directory.stdout.strip, "bin", "concourse")
+  describe command("#{command_full_path} --version") do
+    its('exit_status') { should eq 0 }
+    its('stdout') { should_not be_empty }
+    its('stdout') { should match /#{plan_pkg_version}/ }
+    its('stderr') { should be_empty }
+  end
+end

--- a/controls/concourse_works.rb
+++ b/controls/concourse_works.rb
@@ -16,7 +16,6 @@ control 'core-plans-concourse-works' do
   describe plan_installation_directory do
     its('exit_status') { should eq 0 }
     its('stdout') { should_not be_empty }
-    its('stderr') { should be_empty }
   end
   
   plan_pkg_version = plan_installation_directory.stdout.split("/")[5]
@@ -25,6 +24,5 @@ control 'core-plans-concourse-works' do
     its('exit_status') { should eq 0 }
     its('stdout') { should_not be_empty }
     its('stdout') { should match /#{plan_pkg_version}/ }
-    its('stderr') { should be_empty }
   end
 end

--- a/hooks/run
+++ b/hooks/run
@@ -1,8 +1,0 @@
-#!/bin/bash
-
-exec 2>&1
-
-while true; do
-  echo "Sleeping ..."
-  sleep 10
-done

--- a/inspec.yml
+++ b/inspec.yml
@@ -1,7 +1,7 @@
-name: {plan}
-title: Habitat Core Plan {plan}
+name: concourse
+title: Habitat Core Plan concourse
 maintainer: "The Core Planners <chef-core-planners@chef.io>"
-summary: InSpec controls for testing Habitat Core Plan {plan}
+summary: InSpec controls for testing Habitat Core Plan concourse
 version: 0.1.0
 license: Apache-2.0
 inspec_version: '>= 4.18.108'

--- a/plan.ps1
+++ b/plan.ps1
@@ -1,0 +1,18 @@
+$pkg_name="concourse"
+$pkg_origin="core"
+$pkg_version="4.2.2"
+$pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
+$pkg_license=('Apache-2.0')
+$pkg_description="CI that scales with your project"
+$pkg_upstream_url="https://concourse.ci"
+$pkg_source="https://github.com/${pkg_name}/${pkg_name}/releases/download/v${pkg_version}/${pkg_name}_windows_amd64.exe"
+$pkg_filename="${pkg_name}.exe"
+$pkg_shasum="d1ae2b0c6f2b10b11d793527b55a48813c421a6aa73b75a8496f093878114097"
+
+$pkg_bin_dirs=@("bin")
+
+function Invoke-Unpack { }
+
+function Invoke-Install {
+    Copy-Item "$HAB_CACHE_SRC_PATH/$pkg_filename" "$pkg_prefix/bin/" -Force
+}

--- a/plan.sh
+++ b/plan.sh
@@ -1,0 +1,35 @@
+pkg_name=concourse
+pkg_origin=core
+pkg_version="4.2.2"
+pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
+pkg_license=('Apache-2.0')
+pkg_description="CI that scales with your project"
+pkg_upstream_url="https://concourse.ci"
+pkg_source="https://github.com/${pkg_name}/${pkg_name}/releases/download/v${pkg_version}/${pkg_name}_linux_amd64"
+pkg_filename="${pkg_name}_linux_amd64"
+pkg_shasum="5180903fee6a8fcdf8ba5bd34f270c5c467342f45534692af16f2951181e8749"
+
+pkg_deps=(
+  core/glibc
+)
+pkg_build_deps=(
+  core/patchelf
+)
+pkg_bin_dirs=(bin)
+
+do_unpack() {
+  pushd "${HAB_CACHE_SRC_PATH}"
+    mv "${pkg_name}_linux_amd64" "${pkg_name}"
+    chmod +x "${pkg_name}"
+  popd
+}
+
+do_build(){
+  return 0
+}
+
+do_install(){
+  cp "$HAB_CACHE_SRC_PATH/${pkg_name}" "${pkg_prefix}/bin/${pkg_name}" || exit 1
+  patchelf --interpreter "$(pkg_path_for glibc)/lib/ld-linux-x86-64.so.2" \
+    "${pkg_prefix}/bin/concourse"
+}


### PR DESCRIPTION
Tests all passing on studio:

```rspec
» Installing chef/inspec
☁ Determining latest version of chef/inspec in the 'stable' channel
→ Using chef/inspec/4.22.8/20200804103652
★ Install of chef/inspec/4.22.8/20200804103652 complete with 0 new packages installed.

Profile: Habitat Core Plan concourse (concourse)
Version: 0.1.0
Target:  local://

  ✔  core-plans-concourse-works: Ensure concourse works as expected
     ✔  Command: `hab pkg path core/concourse` exit_status is expected to eq 0
     ✔  Command: `hab pkg path core/concourse` stdout is expected not to be empty
     ✔  Command: `hab pkg path core/concourse` stderr is expected to be empty
     ✔  Command: `/hab/pkgs/core/concourse/4.2.2/20200818102606/bin/concourse --version` exit_status is expected to eq 0
     ✔  Command: `/hab/pkgs/core/concourse/4.2.2/20200818102606/bin/concourse --version` stdout is expected not to be empty
     ✔  Command: `/hab/pkgs/core/concourse/4.2.2/20200818102606/bin/concourse --version` stdout is expected to match /4.2.2/
     ✔  Command: `/hab/pkgs/core/concourse/4.2.2/20200818102606/bin/concourse --version` stderr is expected to be empty
  ✔  core-plans-concourse-exists: Ensure concourse exists
     ✔  Command: `hab pkg path core/concourse` exit_status is expected to eq 0
     ✔  Command: `hab pkg path core/concourse` stdout is expected not to be empty
     ✔  Command: `hab pkg path core/concourse` stderr is expected to be empty
     ✔  File /hab/pkgs/core/concourse/4.2.2/20200818102606/bin/concourse is expected to exist
     ✔  File /hab/pkgs/core/concourse/4.2.2/20200818102606/bin/concourse is expected to be executable


Profile Summary: 2 successful controls, 0 control failures, 0 controls skipped
Test Summary: 12 successful, 0 failures, 0 skipped
```